### PR TITLE
fix: route app ingress to our service

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -13,6 +13,16 @@ domains:
     type: ALIAS
     zone: imvinhnguyen.com
 
+# Route all traffic to our service (the imported app's ingress still
+# referenced the old component name).
+ingress:
+  rules:
+    - component:
+        name: sudovinh-imvinhnguyen
+      match:
+        path:
+          prefix: /
+
 services:
   - name: sudovinh-imvinhnguyen
     github:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,21 @@ resource "digitalocean_app" "imvinhnguyen_web" {
       zone = "imvinhnguyen.com"
     }
 
+    # Route all traffic to our service. Declared explicitly because the
+    # imported app's ingress still referenced the old component name.
+    ingress {
+      rule {
+        component {
+          name = "sudovinh-imvinhnguyen"
+        }
+        match {
+          path {
+            prefix = "/"
+          }
+        }
+      }
+    }
+
     service {
       name               = "sudovinh-imvinhnguyen"
       instance_count     = 1


### PR DESCRIPTION
Importing the existing DigitalOcean app into Terraform surfaced an ingress rule that still referenced its old component name (`vinhnguyen-social-landing-page`). Once the service was renamed to `sudovinh-imvinhnguyen`, DO rejected the spec:

> `400 ... ingress.rules.rule.component.name: Unable to find component with name "vinhnguyen-social-landing-page"`

This declares an explicit ingress routing `/` to `sudovinh-imvinhnguyen` in both `terraform/main.tf` and `.do/app.yaml`.

**Already applied** via `terraform apply` — the app now builds from this repo and **imvinhnguyen.com** / **www.imvinhnguyen.com** serve the new site (verified: 200, HSTS present, `/health` healthy). Committing so the repo and the `deploy-app.yaml` workflow stay in sync with the live spec.

https://claude.ai/code/session_019sW5rQ2aKhWwQ78D3XS6P6