### PR TITLE
docs: drop the Go-blueprint scaffolding note

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,3 @@ make terraform-apply
 - **[modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite)** — pure-Go SQLite (used only by `/health`; no CGO)
 - **flox** · **Docker** · **Terraform** · **DigitalOcean App Platform**
 
-## Notes
-
-Originally scaffolded with [Go-blueprint by Melkey](https://github.com/Melkeydev/go-blueprint).


### PR DESCRIPTION
Removes the leftover `## Notes` section ("Originally scaffolded with Go-blueprint by Melkey") now that the project has diverged well past the scaffold.

https://claude.ai/code/session_019sW5rQ2aKhWwQ78D3XS6P6